### PR TITLE
Fix problem with newer version of commander

### DIFF
--- a/lib/html-linter-cli.js
+++ b/lib/html-linter-cli.js
@@ -9,7 +9,7 @@ var program = commander
     .version('1.0.0')
     .option('--config [filePath]', 'config file')
     .arguments('[fileList...]')
-    .action(function (args) { return fileList = args; })
+    .action(function (args) { return fileList = args.length > 0 ? args : undefined; })
     .parse(process.argv);
 var configFilePath = program.config;
 if (!configFilePath) {

--- a/lib/html-linter-cli.ts
+++ b/lib/html-linter-cli.ts
@@ -8,7 +8,7 @@ const program = commander
   .version('1.0.0')
   .option('--config [filePath]', 'config file')
   .arguments('[fileList...]')
-  .action((args: string[]) => fileList = args)
+  .action((args: string[]) => fileList = args.length > 0 ? args : undefined)
   .parse(process.argv);
 
 const configFilePath = program.config;


### PR DESCRIPTION
Hi,
newer versions of `commander` will always triggers `action`, passing an empty array when there are no extra args [1].
Since `Linter.lint` is expecting `fileList` to be `undefined` when there are no files, the linter will now always use `fileList` and ignore `config.files`.
This will cause html-linter, when no file is specified, to reject the execution with "No files to lint" message.

[1] https://github.com/tj/commander.js/issues/850